### PR TITLE
Multiple update readers

### DIFF
--- a/internal/bot/configuration/configuration.go
+++ b/internal/bot/configuration/configuration.go
@@ -1,13 +1,14 @@
 package configuration
 
 type StartupConfig struct {
-	BotAPIToken     string `env:"BOT_TOKEN,required,notEmpty"`
-	DatabaseURL     string `env:"DATABASE_URL,required,notEmpty"`
-	Debug           bool   `env:"DEBUG"`
-	TGUpdateTimeout int    `env:"UPDATE_TIMEOUT" envDefault:"60"`
-	MetricsUser     string `env:"METRICS_USER,required,notEmpty"`
-	MetricsPassword string `env:"METRICS_PASSWORD,required,notEmpty"`
-	MetricsPort     int    `env:"METRICS_PORT,required,notEmpty"`
+	BotAPIToken         string `env:"BOT_TOKEN,required,notEmpty"`
+	DatabaseURL         string `env:"DATABASE_URL,required,notEmpty"`
+	Debug               bool   `env:"DEBUG"`
+	TGUpdateTimeout     int    `env:"UPDATE_TIMEOUT" envDefault:"60"`
+	UpdateReadersNumber int    `env:"UPDATE_READERS_NUMBER" envDefault:"10"`
+	MetricsUser         string `env:"METRICS_USER,required,notEmpty"`
+	MetricsPassword     string `env:"METRICS_PASSWORD,required,notEmpty"`
+	MetricsPort         int    `env:"METRICS_PORT,required,notEmpty"`
 }
 
 type PopulatorConfig struct {


### PR DESCRIPTION
Add multiple update readers so that a service can serve many messages concurrently.